### PR TITLE
Fix/24 fix user blank

### DIFF
--- a/src/main/java/site/examready2025/quiz/domain/user/entity/User.java
+++ b/src/main/java/site/examready2025/quiz/domain/user/entity/User.java
@@ -1,6 +1,7 @@
 package site.examready2025.quiz.domain.user.entity;
 
 import jakarta.persistence.*;
+import jakarta.validation.constraints.NotBlank;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -21,6 +22,7 @@ public class User {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
+    @NotBlank(message = "Name cannot be blank")
     @Column(nullable = false, length = 15)
     private String name;
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -13,6 +13,7 @@ spring:
       hibernate.dialect: org.hibernate.dialect.MySQL8Dialect
       hibernate.format_sql: true
       hibernate.transaction.jta.platform: org.hibernate.engine.transaction.jta.platform.internal.NoJtaPlatform
+<<<<<<< Updated upstream
 
 management:
   endpoint:
@@ -22,3 +23,5 @@ management:
     web:
       exposure:
         include: "health"
+=======
+>>>>>>> Stashed changes


### PR DESCRIPTION
## 📌연관 이슈
<!-- #Issue_number -->
#24 
## ✨작업 내용
<!-- 작업 코드 내용 -->
User 엔티티 name에 notblank 추가 (공백일 때, 유저 생성되지 않도록 수정)
## PR 유형

- [x] 새로운 기능 추가
- [x] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 스크린샷 (선택) 
![image](https://github.com/user-attachments/assets/4b074fb8-6c85-4a8d-b5c4-ae6f8a1f6be1)

## 📑비고
