### PR TITLE
[Feat] 퀴즈 URL_UUID 적용 (보안 강화)

### DIFF
--- a/src/main/java/site/examready2025/quiz/domain/quiz/dto/QuizResponseDto.java
+++ b/src/main/java/site/examready2025/quiz/domain/quiz/dto/QuizResponseDto.java
@@ -12,4 +12,5 @@ public class QuizResponseDto {
     private Long creatorUserId;
     private String title;
     private LocalDateTime createdAt;
+    private String shareKey;
 }

--- a/src/main/java/site/examready2025/quiz/domain/quiz/entity/Quiz.java
+++ b/src/main/java/site/examready2025/quiz/domain/quiz/entity/Quiz.java
@@ -4,13 +4,14 @@ import jakarta.persistence.*;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import site.examready2025.quiz.domain.question.entity.Question;
+import lombok.Setter;
 import site.examready2025.quiz.domain.response.entity.Response;
 import site.examready2025.quiz.domain.user.entity.User;
 
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.UUID;
 
 @Entity
 @Getter
@@ -32,13 +33,25 @@ public class Quiz {
     @Column(nullable = false, updatable = false)
     private LocalDateTime createdAt;
 
+    @Setter
+    @Column(nullable = false, unique = true, length = 36)
+    private String shareKey;
+
     @OneToMany(mappedBy = "quiz")
     private List<Response> responses = new ArrayList<>();
 
     @Builder
-    public Quiz(User creator, String title, LocalDateTime createdAt){
+    public Quiz(User creator, String title, LocalDateTime createdAt, String shareKey){
         this.creator = creator;
         this.title = title;
         this.createdAt = createdAt;
+        this.shareKey = shareKey;
+    }
+
+    @PrePersist
+    private void initializeShareKey() {
+        if (this.shareKey == null) {
+            this.shareKey = UUID.randomUUID().toString();
+        }
     }
 }

--- a/src/main/java/site/examready2025/quiz/domain/quiz/service/QuizService.java
+++ b/src/main/java/site/examready2025/quiz/domain/quiz/service/QuizService.java
@@ -43,6 +43,7 @@ public class QuizService {
                 .title(quiz.getTitle())
                 .createdAt(quiz.getCreatedAt())
                 .creatorUserId(creator.getId())
+                .shareKey(quiz.getShareKey())
                 .build();
     }
 

--- a/src/main/java/site/examready2025/quiz/domain/share/service/ShareService.java
+++ b/src/main/java/site/examready2025/quiz/domain/share/service/ShareService.java
@@ -20,7 +20,7 @@ public class ShareService {
                 .orElseThrow(() -> new IllegalArgumentException("퀴즈를 찾을 수 없습니다. 퀴즈 ID: " + requestDto.getQuizId()));
 
         // 공유 URL 생성
-        String shareUrl = "https://examready2025.site/quiz/" + quiz.getId();
+        String shareUrl = "https://examready2025.site/quiz/" + quiz.getShareKey();
 
         return ShareResponseDto.builder()
                 .shareUrl(shareUrl)


### PR DESCRIPTION
## 📌연관 이슈
<!-- #Issue_number -->
#45 
## ✨작업 내용
<!-- 작업 코드 내용 -->

- quiz 엔티티에 shareKey 추가
- @PrePersist 어노테이션 사용해, shareKey 값 생성 후 저장되도록 함
- 공유 URL의 quizId을 UUID로 변경 (보안 강화)

## PR 유형

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 스크린샷 (선택) 
![image](https://github.com/user-attachments/assets/eb391992-ef2c-4013-830b-ff94a3528f94)
![image](https://github.com/user-attachments/assets/51669736-2a50-4f64-ae21-e46fea8b060e)

## 📑비고
